### PR TITLE
Improve SEO with meta tags

### DIFF
--- a/attendance.html
+++ b/attendance.html
@@ -3,6 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Jednoduchá aplikácia na evidenciu pracovnej dochádzky." />
+  <meta name="keywords" content="dochádzka, pracovná dochádzka, dochádzkový list" />
+  <link rel="canonical" href="https://vykazuje.me/attendance.html" />
+  <meta property="og:title" content="Pracovná dochádzka" />
+  <meta property="og:description" content="Jednoduchá aplikácia na evidenciu pracovnej dochádzky." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://vykazuje.me/attendance.html" />
+  <meta property="og:image" content="https://vykazuje.me/favicon-32x32.png" />
   <title>Pracovná dochádzka</title>
   <style>
     body { font-family: sans-serif; padding: 20px; }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon-32x32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Jednoduchý nástroj na generovanie a evidenciu pracovnej dochádzky." />
+    <meta name="keywords" content="dochádzka, dochádzkový list, pracovná dochádzka" />
+    <link rel="canonical" href="https://vykazuje.me/" />
+    <meta property="og:title" content="Vykazujeme" />
+    <meta property="og:description" content="Jednoduchý nástroj na generovanie a evidenciu pracovnej dochádzky." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://vykazuje.me/" />
+    <meta property="og:image" content="https://vykazuje.me/favicon-32x32.png" />
     <title>Vykazujeme</title>
   </head>
   <body>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,8 +2,12 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://vykazuje.me/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://vykazuje.me/attendance.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add canonical URL, meta description and Open Graph tags to HTML pages
- include update frequency and priority in sitemap

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c8c38bb8c8332a1d16ad5358226b5