### PR TITLE
feat: improve print layout

### DIFF
--- a/src/Attendance.tsx
+++ b/src/Attendance.tsx
@@ -107,7 +107,15 @@ export default function Attendance(): JSX.Element {
     <>
       <style>{styles}</style>
       <div>
-        <h1 className="mt-2 text-3xl tracking-tight text-pretty">Dochádzka</h1>
+        <div className="flex items-center justify-center">
+          <h1 className="mt-2 text-3xl tracking-tight text-pretty">Dochádzka</h1>
+          <button
+            onClick={() => window.print()}
+            className="ml-4 bg-green-500 hover:bg-green-600 text-white font-medium py-2 px-4 rounded print:hidden"
+          >
+            Tlačiť
+          </button>
+        </div>
         <UserInfo
           firstName={firstName}
           lastName={lastName}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -25,8 +25,6 @@ export const styles = `
     /* PRINT OPTIMIZATION FOR A4 */
     @media print {
       html, body {
-        width: 200mm;
-        height: 297mm;
         margin: 0 !important;
         padding: 0 !important;
         font-size: 11px !important;
@@ -34,7 +32,10 @@ export const styles = `
       }
       @page {
         size: A4 portrait;
-        margin: 10mm 8mm 10mm 8mm;
+        margin: 0;
+      }
+      body {
+        margin: 10mm 8mm 10mm 8mm !important;
       }
       h1 {
         font-size: 18px !important;


### PR DESCRIPTION
## Summary
- remove default print headers and force single page output
- add tailwind-styled print button hidden during printing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689060467eb48332861a7774f8a282ca