### PR TITLE
Add routing and layout shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/About.tsx
+++ b/src/About.tsx
@@ -1,0 +1,4 @@
+export default function About() {
+  return <div>About</div>;
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,22 @@
-import React from 'react';
+import { Routes, Route } from 'react-router-dom';
 import Attendance from './Attendance';
+import About from './About';
+import Guides from './Guides';
+import Examples from './Examples';
+import Landing from './Landing';
+import Layout from './Layout';
 
-function App() {
-  return <Attendance />;
+export default function App() {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route path="/" element={<Landing />} />
+        <Route path="/attendance" element={<Attendance />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/guides" element={<Guides />} />
+        <Route path="/examples" element={<Examples />} />
+      </Route>
+    </Routes>
+  );
 }
 
-export default App;

--- a/src/Examples.tsx
+++ b/src/Examples.tsx
@@ -1,0 +1,4 @@
+export default function Examples() {
+  return <div>Examples</div>;
+}
+

--- a/src/Guides.tsx
+++ b/src/Guides.tsx
@@ -1,0 +1,4 @@
+export default function Guides() {
+  return <div>Guides</div>;
+}
+

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+
+export default function Header() {
+  return (
+    <header>
+      <nav>
+        <ul className="flex gap-4">
+          <li><Link to="/">Home</Link></li>
+          <li><Link to="/attendance">Attendance</Link></li>
+          <li><Link to="/about">About</Link></li>
+          <li><Link to="/guides">Guides</Link></li>
+          <li><Link to="/examples">Examples</Link></li>
+        </ul>
+      </nav>
+    </header>
+  );
+}
+

--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -1,0 +1,4 @@
+export default function Landing() {
+  return <div>Landing Page</div>;
+}
+

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,0 +1,20 @@
+import Header from './Header';
+import Sidebar from './Sidebar';
+import { Outlet } from 'react-router-dom';
+
+type LayoutProps = {
+  showSidebar?: boolean
+}
+
+export default function Layout({ showSidebar = false }: LayoutProps) {
+  return (
+    <>
+      <Header />
+      <div className="flex">
+        {showSidebar && <Sidebar />}
+        <Outlet />
+      </div>
+    </>
+  );
+}
+

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -1,0 +1,4 @@
+export default function Sidebar() {
+  return <aside>Sidebar</aside>;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App.tsx'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- refine routing to include landing, attendance, about, guides, and examples pages
- add navigation links in the header for available routes
- remove unused placeholder pages and introduce a landing page component

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "react-router-dom")*

------
https://chatgpt.com/codex/tasks/task_e_689907fff5b0833283b180e80293cbeb