### PR TITLE
Implement basic hash-based routing with sidebar links

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -1,0 +1,3 @@
+export default function About(): JSX.Element {
+  return <h1>About</h1>;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,42 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Attendance from './Attendance';
+import About from './About';
+import FAQ from './FAQ';
+import Tutorials from './Tutorials';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 
 function App() {
   const [open, setOpen] = useState(false);
+  const [page, setPage] = useState<string>(window.location.hash || '#/attendance');
+
+  useEffect(() => {
+    const onHashChange = () => setPage(window.location.hash || '#/attendance');
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  const renderPage = () => {
+    switch (page) {
+      case '#/about':
+        return <About />;
+      case '#/faq':
+        return <FAQ />;
+      case '#/tutorials':
+        return <Tutorials />;
+      case '#/attendance':
+      default:
+        return <Attendance />;
+    }
+  };
+
   return (
     <>
       <Header onMenuClick={() => setOpen((o) => !o)} />
       <div className='content flex'>
         <Sidebar isOpen={open} />
         <div className='p-6 flex-1'>
-          <Attendance />
+          {renderPage()}
         </div>
       </div>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
     <>
       <Header onMenuClick={() => setOpen((o) => !o)} />
       <div className='content flex'>
-        <Sidebar isOpen={open} />
+        <Sidebar isOpen={open} currentPage={page} />
         <div className='p-6 flex-1'>
           {renderPage()}
         </div>

--- a/src/FAQ.tsx
+++ b/src/FAQ.tsx
@@ -1,0 +1,3 @@
+export default function FAQ(): JSX.Element {
+  return <h1>FAQ</h1>;
+}

--- a/src/Tutorials.tsx
+++ b/src/Tutorials.tsx
@@ -1,0 +1,3 @@
+export default function Tutorials(): JSX.Element {
+  return <h1>Tutorials</h1>;
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,37 +3,38 @@ import classes from './Sidebar.module.scss';
 
 interface SidebarProps {
   isOpen: boolean;
+  currentPage: string;
 }
 
-export default function Sidebar({ isOpen }: SidebarProps) {
+export default function Sidebar({ isOpen, currentPage }: SidebarProps) {
   return (
     <aside className={`${classes.sidebar} ${isOpen ? classes.open : ''}`}>
       <div className={classes.sidebar__content}>
         <nav className="flex flex-col space-y-2 p-2">
           <a
             href="#/about"
-            className="flex items-center gap-2 text-gray-700 hover:text-gray-900 no-underline"
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/about' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
           >
             <Info size={16} />
             About
           </a>
           <a
             href="#/faq"
-            className="flex items-center gap-2 text-gray-700 hover:text-gray-900 no-underline"
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/faq' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
           >
             <HelpCircle size={16} />
             FAQ
           </a>
           <a
             href="#/tutorials"
-            className="flex items-center gap-2 text-gray-700 hover:text-gray-900 no-underline"
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/tutorials' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
           >
             <BookOpen size={16} />
             Tutorials
           </a>
           <a
             href="#/attendance"
-            className="flex items-center gap-2 text-gray-700 hover:text-gray-900 no-underline"
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/attendance' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
           >
             <ClipboardList size={16} />
             Attendance

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
+import { Info, HelpCircle, BookOpen, ClipboardList } from 'lucide-react';
 import classes from './Sidebar.module.scss';
-
 
 interface SidebarProps {
   isOpen: boolean;
@@ -7,17 +7,39 @@ interface SidebarProps {
 
 export default function Sidebar({ isOpen }: SidebarProps) {
   return (
-    <aside
-      className={`${classes.sidebar} ${
-        isOpen ? classes.open: ''
-      }`}
-    >
-      <nav className="flex flex-col space-y-2">
-        <a href="#/about">About</a>
-        <a href="#/faq">FAQ</a>
-        <a href="#/tutorials">Tutorials</a>
-        <a href="#/attendance">Attendance</a>
-      </nav>
+    <aside className={`${classes.sidebar} ${isOpen ? classes.open : ''}`}>
+      <div className={classes.sidebar__content}>
+        <nav className="flex flex-col space-y-2 p-2">
+          <a
+            href="#/about"
+            className="flex items-center gap-2 text-gray-700 hover:text-gray-900 no-underline"
+          >
+            <Info size={16} />
+            About
+          </a>
+          <a
+            href="#/faq"
+            className="flex items-center gap-2 text-gray-700 hover:text-gray-900 no-underline"
+          >
+            <HelpCircle size={16} />
+            FAQ
+          </a>
+          <a
+            href="#/tutorials"
+            className="flex items-center gap-2 text-gray-700 hover:text-gray-900 no-underline"
+          >
+            <BookOpen size={16} />
+            Tutorials
+          </a>
+          <a
+            href="#/attendance"
+            className="flex items-center gap-2 text-gray-700 hover:text-gray-900 no-underline"
+          >
+            <ClipboardList size={16} />
+            Attendance
+          </a>
+        </nav>
+      </div>
     </aside>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Info, HelpCircle, BookOpen, ClipboardList } from 'lucide-react';
+import { Info, HelpCircle, BookOpen, ClipboardList, Home } from 'lucide-react';
 import classes from './Sidebar.module.scss';
 
 interface SidebarProps {
@@ -12,32 +12,32 @@ export default function Sidebar({ isOpen, currentPage }: SidebarProps) {
       <div className={classes.sidebar__content}>
         <nav className="flex flex-col space-y-2 p-2">
           <a
-            href="#/about"
+            href="#/home"
             className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/about' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
           >
-            <Info size={16} />
-            About
+            <Home size={16} />
+            Domov
           </a>
           <a
             href="#/faq"
             className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/faq' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
           >
             <HelpCircle size={16} />
-            FAQ
+             Časté otázky
           </a>
           <a
             href="#/tutorials"
             className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/tutorials' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
           >
             <BookOpen size={16} />
-            Tutorials
+            Návody
           </a>
           <a
             href="#/attendance"
             className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/attendance' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
           >
             <ClipboardList size={16} />
-            Attendance
+            Dochádzka
           </a>
         </nav>
       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,7 +12,12 @@ export default function Sidebar({ isOpen }: SidebarProps) {
         isOpen ? classes.open: ''
       }`}
     >
-      Working on the main menu. Check back soon!
+      <nav className="flex flex-col space-y-2">
+        <a href="#/about">About</a>
+        <a href="#/faq">FAQ</a>
+        <a href="#/tutorials">Tutorials</a>
+        <a href="#/attendance">Attendance</a>
+      </nav>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- replace sidebar placeholder with vertical navigation links
- add simple hash-based routing to switch between About, FAQ, Tutorials, and Attendance pages
- add placeholder components for About, FAQ, and Tutorials pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aff8e17dc8332bf16b1688e6d147e