### PR TITLE
feat: add landing page

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -1,3 +1,22 @@
+import React from 'react';
+
 export default function About(): JSX.Element {
-  return <h1>About</h1>;
+  return (
+    <div className="flex items-center justify-center min-h-full bg-gradient-to-br from-blue-50 to-blue-100 py-10">
+      <div className="max-w-xl w-full bg-white/90 border border-gray-200 rounded-lg shadow p-6 text-center space-y-4">
+        <img src="/favicon-32x32.png" alt="logo" className="w-16 h-16 mx-auto" />
+        <h1 className="text-3xl md:text-4xl font-bold">Rýchlo. Intuitívne. Moderne.</h1>
+        <p className="text-gray-700">
+          Stránka <strong>vykazuje.me</strong> vám pomáha rýchlo, intuitívne a moderne vyplniť zamestnaneckú dochádzku.
+          Nestrácajte už čas v Exceli a splňte si túto úlohu za menej ako minútu. Už netreba nič vyplňovať. Všetko je
+          pripravené. Stačí sa len podpísať a vyklikať si dni, kedy ste nepracovali.
+        </p>
+        <p className="text-gray-700">
+          Pozrite si viac v <a href="#/tutorials" className="text-blue-600 hover:underline">návodoch</a> alebo rovno
+          prejdite na <a href="#/attendance" className="text-blue-600 hover:underline">dochádzku</a>. Ak vám nebude
+          niečo jasné, skúste <a href="#/faq" className="text-blue-600 hover:underline">časté otázky</a>.
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,10 +8,10 @@ import Sidebar from './components/Sidebar';
 
 function App() {
   const [open, setOpen] = useState(false);
-  const [page, setPage] = useState<string>(window.location.hash || '#/attendance');
+  const [page, setPage] = useState<string>(window.location.hash || '#/about');
 
   useEffect(() => {
-    const onHashChange = () => setPage(window.location.hash || '#/attendance');
+    const onHashChange = () => setPage(window.location.hash || '#/about');
     window.addEventListener('hashchange', onHashChange);
     return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
@@ -19,6 +19,7 @@ function App() {
   const renderPage = () => {
     switch (page) {
       case '#/about':
+      case '#/home':
         return <About />;
       case '#/faq':
         return <FAQ />;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import FAQ from './FAQ';
 import Tutorials from './Tutorials';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
+import Footer from './components/Footer';
 
 function App() {
   const [open, setOpen] = useState(false);
@@ -34,12 +35,13 @@ function App() {
   return (
     <>
       <Header onMenuClick={() => setOpen((o) => !o)} />
-      <div className='content flex'>
+      <div className='content flex pb-8'>
         <Sidebar isOpen={open} currentPage={page} />
         <div className='p-6 flex-1'>
           {renderPage()}
         </div>
       </div>
+      <Footer />
     </>
   );
 }

--- a/src/Tutorials.tsx
+++ b/src/Tutorials.tsx
@@ -1,3 +1,116 @@
 export default function Tutorials(): JSX.Element {
-  return <h1>Tutorials</h1>;
+  return (
+    <article className='max-w-3xl mx-auto space-y-10 text-gray-800 leading-relaxed'>
+      <header className='space-y-2'>
+        <h1 className='text-3xl font-semibold tracking-tight'>
+          Návod k vyplneniu dochádzky
+        </h1>
+        <p className='text-sm text-gray-500'>
+          Stručné pokyny pre vyplnenie, tlač a označovanie neprítomnosti.
+        </p>
+      </header>
+
+      <section className='space-y-3'>
+        <h2 className='text-2xl font-semibold'>Osobné údaje</h2>
+        <p>
+          V týchto dvoch poliach si vyplňte vaše meno a priezvisko. Tieto údaje
+          sa zobrazia pri tlači.
+        </p>
+      </section>
+
+      <section className='space-y-3'>
+        <h2 className='text-2xl font-semibold'>Prepínanie mesiaca</h2>
+        <p>
+          Tieto dve tlačidlá slúžia na prepínanie mesiaca. Ak sa vám napríklad
+          zobrazuje
+          <span className='font-semibold'> Obdobie: máj 2025</span> a želáte si
+          vyplniť dochádzku za jún, stlačte tlačidlo &nbsp;
+          <kbd className='inline-block align-middle border px-2 py-0.5 rounded text-sm font-mono bg-gray-100'>
+            Nasledujúci mesiac
+          </kbd>
+          &nbsp; raz. V prípade, že potrebujete iný mesiac, opakujte stláčanie v
+          smere, v akom potrebujete.
+        </p>
+      </section>
+
+      <section className='space-y-4'>
+        <h2 className='text-2xl font-semibold'>Režimy dochádzky</h2>
+        <p>Na stránke sa nachádza prepínač na dochádzkový mód.</p>
+
+        <dl className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+          <div className='space-y-1 rounded-lg border p-4'>
+            <dt className='font-semibold'>Štandardný mód</dt>
+            <dd className='text-gray-600'>
+              Slúži pre dochádzku zamestnancov na trvalý pracovný pomer.
+            </dd>
+          </div>
+
+          <div className='space-y-1 rounded-lg border p-4'>
+            <dt className='font-semibold'>Skrátený mód</dt>
+            <dd className='text-gray-600'>
+              Určený pre dôchodcov a brigádnikov, ktorí môžu odpracovať iba 40
+              hodín týždenne.
+            </dd>
+          </div>
+        </dl>
+
+        <p
+          role='note'
+          className='border-l-4 border-amber-400 bg-amber-50 p-4 text-amber-900'
+        >
+          <em>
+            Prosím, vezmite na vedomie, že skrátený režim neobsahuje údaje o
+            obedoch, v súlade so štandardom.
+          </em>
+        </p>
+      </section>
+
+      <section className='space-y-3'>
+        <h2 className='text-2xl font-semibold'>Označenie neprítomnosti</h2>
+        <p>
+          <span>
+            Stĺpec <span className='font-semibold'>Mimo práce</span> Vám
+            umožnuje zvoliť si dni kedy ste nepracovali.
+          </span>
+        </p>
+        <p className='inline-flex items-center gap-2'>
+          <span>Kliknutím na tento checkbox</span>
+          <span
+            aria-hidden='true'
+            className='inline-flex h-5 w-5 items-center justify-center rounded border'
+          >
+            ☑️
+          </span>
+          <span>si viete vybrať také dni.</span>
+        </p>
+        <p>
+          Po výbere sa zobrazí zoznam dôvodov neprítomnosti. Tu si môžete vybrať
+          jeden zo štandardných dôvodov. Prednastaveným dôvodom je{' '}
+          <span className='font-semibold'>dovolenka</span>.
+        </p>
+      </section>
+
+      <section className='space-y-3'>
+        <h2 className='text-2xl font-semibold'>Súhrn a výpočet hodín</h2>
+        <p>
+          Vyberte všetky dni, kedy ste neboli v práci. Zvoľte dôvody a potom sa
+          vám v spodnej časti nástroja zobrazí súhrn. Nástroj predpokladá
+          8-hodinový pracovný deň a 40 minút na obed, ktorý nie je zahrnutý v
+          hodinách.
+        </p>
+      </section>
+
+      <section className='space-y-3'>
+        <h2 className='text-2xl font-semibold'>Tlač</h2>
+        <p>
+          Keď budete hotoví, stlačte &nbsp;
+          <kbd className='inline-block align-middle border px-2 py-0.5 rounded text-sm font-mono bg-gray-100'>
+            Tlačiť
+          </kbd>
+          &nbsp;a náhľad tlače sa vám zobrazí, odkiaľ môžete spustiť tlač alebo
+          uložiť súbor ako PDF.
+        </p>
+      </section>
+    </article>
+  );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <footer className='fixed left-0 bottom-0 w-full bg-black text-white text-xs p-2'>
+      Pinit, s.r.o (2025). All rights reserved
+    </footer>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Info, HelpCircle, BookOpen, ClipboardList, Home } from 'lucide-react';
+import { HelpCircle, BookOpen, ClipboardList, Home } from 'lucide-react';
 import classes from './Sidebar.module.scss';
 
 interface SidebarProps {
@@ -12,7 +12,7 @@ export default function Sidebar({ isOpen, currentPage }: SidebarProps) {
       <div className={classes.sidebar__content}>
         <nav className="flex flex-col space-y-2 p-2">
           <a
-            href="#/home"
+            href="#/about"
             className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/about' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
           >
             <Home size={16} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,34 +10,51 @@ export default function Sidebar({ isOpen, currentPage }: SidebarProps) {
   return (
     <aside className={`${classes.sidebar} ${isOpen ? classes.open : ''}`}>
       <div className={classes.sidebar__content}>
-        <nav className="flex flex-col space-y-2 p-2">
+        <nav className='flex flex-col space-y-2 p-2'>
           <a
-            href="#/about"
-            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/about' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
+            href='#/about'
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${
+              currentPage === '#/about'
+                ? 'bg-gray-200 text-gray-900 font-medium'
+                : ''
+            }`}
           >
             <Home size={16} />
             Domov
           </a>
           <a
-            href="#/faq"
-            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/faq' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
+            href='#/attendance'
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${
+              currentPage === '#/attendance'
+                ? 'bg-gray-200 text-gray-900 font-medium'
+                : ''
+            }`}
           >
-            <HelpCircle size={16} />
-             Časté otázky
+            <ClipboardList size={16} />
+            Dochádzka
           </a>
           <a
-            href="#/tutorials"
-            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/tutorials' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
+            href='#/tutorials'
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${
+              currentPage === '#/tutorials'
+                ? 'bg-gray-200 text-gray-900 font-medium'
+                : ''
+            }`}
           >
             <BookOpen size={16} />
             Návody
           </a>
+
           <a
-            href="#/attendance"
-            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${currentPage === '#/attendance' ? 'bg-gray-200 text-gray-900 font-medium' : ''}`}
+            href='#/faq'
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${
+              currentPage === '#/faq'
+                ? 'bg-gray-200 text-gray-900 font-medium'
+                : ''
+            }`}
           >
-            <ClipboardList size={16} />
-            Dochádzka
+            <HelpCircle size={16} />
+            Časté otázky
           </a>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- add gradient about page with corrected Slovak copy
- make about page the default landing page
- fix sidebar home link to point to the about page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b13a45e3883328a6d1440d8ec4fe5