### PR TITLE
Add Slovak terms and conditions page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Attendance from './Attendance';
 import About from './About';
 import FAQ from './FAQ';
 import Tutorials from './Tutorials';
+import Terms from './Terms';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 import Footer from './components/Footer';
@@ -26,6 +27,8 @@ function App() {
         return <FAQ />;
       case '#/tutorials':
         return <Tutorials />;
+      case '#/terms':
+        return <Terms />;
       case '#/attendance':
       default:
         return <Attendance />;

--- a/src/Terms.tsx
+++ b/src/Terms.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function Terms(): JSX.Element {
+  return (
+    <div className="flex items-center justify-center min-h-full py-10">
+      <div className="max-w-2xl w-full bg-white/90 border border-gray-200 rounded-lg shadow p-6 space-y-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-center">Podmienky používania</h1>
+        <p className="text-gray-700">
+          Tento nástroj je dostupný zadarmo pre všetkých používateľov. Používaním stránky súhlasíte s nasledujúcimi
+          pravidlami:
+        </p>
+        <ul className="list-disc list-inside text-gray-700 space-y-1">
+          <li>Softvér je možné používať bezplatne a bez obmedzení.</li>
+          <li>Autor nezodpovedá za prípadné škody spôsobené používaním nástroja.</li>
+          <li>Nástroj je poskytovaný "tak ako je" bez akejkoľvek záruky správnosti alebo dostupnosti.</li>
+          <li>Je zakázané využívať nástroj na nelegálne účely alebo na poškodenie iných osôb.</li>
+          <li>Prevádzkovateľ si vyhradzuje právo kedykoľvek upraviť alebo ukončiť poskytovanie služby.</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle, BookOpen, ClipboardList, Home } from 'lucide-react';
+import { HelpCircle, BookOpen, ClipboardList, Home, FileText } from 'lucide-react';
 import classes from './Sidebar.module.scss';
 
 interface SidebarProps {
@@ -55,6 +55,17 @@ export default function Sidebar({ isOpen, currentPage }: SidebarProps) {
           >
             <HelpCircle size={16} />
             Časté otázky
+          </a>
+          <a
+            href='#/terms'
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${
+              currentPage === '#/terms'
+                ? 'bg-gray-200 text-gray-900 font-medium'
+                : ''
+            }`}
+          >
+            <FileText size={16} />
+            Podmienky používania
           </a>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- add "Podmienky používania" page with general rules for free software use
- link terms page from sidebar navigation
- include terms route in app router

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b62b145bc8332a3f05214781f0440