### PR TITLE
Add cookie consent banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Tutorials from './Tutorials';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 import Footer from './components/Footer';
+import CookieConsent from './components/CookieConsent';
 
 function App() {
   const [open, setOpen] = useState(false);
@@ -42,6 +43,7 @@ function App() {
         </div>
       </div>
       <Footer />
+      <CookieConsent />
     </>
   );
 }

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from 'react';
+
+export default function CookieConsent() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookie-consent');
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem('cookie-consent', 'true');
+    setVisible(false);
+  };
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className='fixed bottom-0 left-0 w-full bg-gray-800 text-white text-sm p-4 flex flex-col sm:flex-row items-center justify-center gap-2 z-50'>
+      <span>
+        This site uses cookies only for Google AdSense. By using this site, you agree to the use of cookies for ads.
+      </span>
+      <button
+        onClick={accept}
+        className='bg-white text-gray-800 px-4 py-1 rounded'
+      >
+        Accept
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add cookie consent banner noting that cookies are used only for Google AdSense
- include the banner in the app layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b634e166c83329fd86ef97de63710