### PR TITLE
Show EU-specific cookie consent with learn more option

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -4,10 +4,24 @@ export default function CookieConsent() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const consent = localStorage.getItem('cookie-consent');
-    if (!consent) {
-      setVisible(true);
-    }
+    const checkConsent = async () => {
+      const consent = localStorage.getItem('cookie-consent');
+      if (consent) {
+        return;
+      }
+
+      try {
+        const res = await fetch('https://ipapi.co/json/');
+        const data = await res.json();
+        if (data?.in_eu) {
+          setVisible(true);
+        }
+      } catch (err) {
+        console.error('Failed to determine EU status', err);
+      }
+    };
+
+    checkConsent();
   }, []);
 
   const accept = () => {
@@ -22,8 +36,14 @@ export default function CookieConsent() {
   return (
     <div className='fixed bottom-0 left-0 w-full bg-gray-800 text-white text-sm p-4 flex flex-col sm:flex-row items-center justify-center gap-2 z-50'>
       <span>
-        This site uses cookies only for Google AdSense. By using this site, you agree to the use of cookies for ads.
+        This site uses advertisement/marketing cookies. By using this site, you agree to their use.
       </span>
+      <button
+        onClick={() => window.open('https://support.google.com/adsense/answer/7549925?hl=en', '_blank')}
+        className='bg-gray-700 text-white px-4 py-1 rounded'
+      >
+        Learn more
+      </button>
       <button
         onClick={accept}
         className='bg-white text-gray-800 px-4 py-1 rounded'


### PR DESCRIPTION
## Summary
- Only display cookie consent banner for EU visitors
- Replace AdSense-specific wording with generic advertising/marketing cookies
- Add "Learn more" button linking to Google AdSense cookie information

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c50e15e84833299383a3c838f51da