### PR TITLE
Add navigation component for page links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
       <Header open={open} onMenuClick={() => setOpen((o) => !o)} />
       <div className='content flex pb-8'>
         <Sidebar isOpen={open} currentPage={page} />
-        <div className='p-6 flex-1 pt-16 md:pt-0'>
+        <div className='p-6 mt-6 flex-1 pt-16 md:pt-0'>
           {renderPage()}
         </div>
       </div>

--- a/src/Attendance.module.scss
+++ b/src/Attendance.module.scss
@@ -1,6 +1,4 @@
 .attendance {
-  font-family: sans-serif;
-  padding: 20px;
 
   @media (max-width: 600px) {
     padding: 10px;

--- a/src/Attendance.tsx
+++ b/src/Attendance.tsx
@@ -151,18 +151,20 @@ export default function Attendance(): JSX.Element {
 
   return (
     <div className={classes.attendance}>
-      <div className='flex items-center justify-center'>
-        <h1 className='mt-2 text-3xl tracking-tight text-pretty'>Dochádzka</h1>
-      </div>
-      <div className={`${classes.period} text-center print:text-left`}>
-        <label>Obdobie:</label>
-        <span>
-          {currentDate.toLocaleDateString('sk-SK', {
-            month: 'long',
-            year: 'numeric',
-          })}
-        </span>
-      </div>
+      <header>
+        <div className='flex items-center justify-center'>
+          <h1 className='text-3xl font-semibold tracking-tight'>Dochádzka</h1>
+        </div>
+        <div className={`${classes.period} text-center print:text-left`}>
+          <label>Obdobie:</label>
+          <span>
+            {currentDate.toLocaleDateString('sk-SK', {
+              month: 'long',
+              year: 'numeric',
+            })}
+          </span>
+        </div>
+      </header>
       <Controls
         setCurrentDate={setCurrentDate}
         shiftType={shiftType}

--- a/src/FAQ.tsx
+++ b/src/FAQ.tsx
@@ -1,39 +1,42 @@
+import Navigation from './components/Navigation';
+
 export default function FAQ(): JSX.Element {
   return (
-    <article className='max-w-3xl mx-auto space-y-8 text-gray-800 leading-relaxed'>
-      <header className='space-y-2'>
-        <h1 className='text-3xl font-semibold tracking-tight'>Časté otázky</h1>
-        <p className='text-sm text-gray-500'>
-          Odpovede na najčastejšie otázky k nástroju.
-        </p>
-      </header>
+    <>
+      <article className='max-w-3xl mx-auto space-y-8 text-gray-800 leading-relaxed'>
+        <header className='space-y-2'>
+          <h1 className='text-3xl font-semibold tracking-tight'>Časté otázky</h1>
+          <p className='text-sm text-gray-500'>
+            Odpovede na najčastejšie otázky k nástroju.
+          </p>
+        </header>
 
-      <section className='space-y-2'>
-        <h2 className='text-xl font-semibold'>Ukladáte moje osobné údaje?</h2>
-        <p>
-          Nie. Všetko, čo na stránke zadáte, zostáva vo vašom prehliadači a
-          nikam sa neposiela. Znamená to, že vaše údaje nikdy neopustia vaše
-          zariadenie.
-        </p>
-      </section>
+        <section className='space-y-2'>
+          <h2 className='text-xl font-semibold'>Ukladáte moje osobné údaje?</h2>
+          <p>
+            Nie. Všetko, čo na stránke zadáte, zostáva vo vašom prehliadači a
+            nikam sa neposiela. Znamená to, že vaše údaje nikdy neopustia vaše
+            zariadenie.
+          </p>
+        </section>
 
-      <section className='space-y-2'>
-        <h2 className='text-xl font-semibold'>Je služba platená?</h2>
-        <p>
-          Služba je úplne bezplatná a nevyžaduje žiadne poplatky. Môžete ju
-          využívať neobmedzene bez akýchkoľvek záväzkov.
-        </p>
-      </section>
+        <section className='space-y-2'>
+          <h2 className='text-xl font-semibold'>Je služba platená?</h2>
+          <p>
+            Služba je úplne bezplatná a nevyžaduje žiadne poplatky. Môžete ju
+            využívať neobmedzene bez akýchkoľvek záväzkov.
+          </p>
+        </section>
 
-      <section className='space-y-2'>
-        <h2 className='text-xl font-semibold'>
-          Môžem si dochádzku uložiť na neskôr?
-        </h2>
-        <p>
-          Momentálne neponúkame možnosť uloženia dochádzky. Je potrebné si ju
-          vytlačiť alebo exportovať hneď po vyplnení, aby ste o údaje neprišli.
-        </p>
-      </section>
+        <section className='space-y-2'>
+          <h2 className='text-xl font-semibold'>
+            Môžem si dochádzku uložiť na neskôr?
+          </h2>
+          <p>
+            Momentálne neponúkame možnosť uloženia dochádzky. Je potrebné si ju
+            vytlačiť alebo exportovať hneď po vyplnení, aby ste o údaje neprišli.
+          </p>
+        </section>
 
       <section className='space-y-2'>
         <h2 className='text-xl font-semibold'>
@@ -142,6 +145,8 @@ export default function FAQ(): JSX.Element {
           tlači.
         </p>
       </section>
-    </article>
+      </article>
+      <Navigation />
+    </>
   );
 }

--- a/src/Tutorials.tsx
+++ b/src/Tutorials.tsx
@@ -6,6 +6,7 @@ import print from './assets/print_button.jpg';
 import reasonOut from './assets/reason_out_extended.jpg';
 import summary from './assets/summary.jpg';
 import timeSelected from './assets/time_selected.jpg';
+import Navigation from './components/Navigation';
 
 export default function Tutorials(): JSX.Element {
   return (
@@ -290,6 +291,7 @@ export default function Tutorials(): JSX.Element {
           </p>
         </section>
       </article>
+      <Navigation />
     </>
   );
 }

--- a/src/Tutorials.tsx
+++ b/src/Tutorials.tsx
@@ -11,7 +11,7 @@ import Navigation from './components/Navigation';
 export default function Tutorials(): JSX.Element {
   return (
     <>
-      <article className='max-w-3xl mx-auto space-y-10 text-gray-800 leading-relaxed mt-4'>
+      <article className='max-w-3xl mx-auto space-y-10 text-gray-800 leading-relaxed'>
         <header className='space-y-2'>
           <h1 className='text-3xl font-semibold tracking-tight'>
             Úvod k ovládacím provkom na stránke

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function Navigation() {
   const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0, behavior: 'auto' });
   };
 
   return (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function Navigation() {
+  return (
+    <nav className="mt-12 flex flex-wrap justify-center gap-4 text-sm">
+      <a href="#/about" className="text-blue-600 hover:underline">
+        Domov
+      </a>
+      <a href="#/attendance" className="text-blue-600 hover:underline">
+        Dochádzka
+      </a>
+      <a href="#/tutorials" className="text-blue-600 hover:underline">
+        Návody
+      </a>
+      <a href="#/faq" className="text-blue-600 hover:underline">
+        Časté otázky
+      </a>
+      <a href="#/terms" className="text-blue-600 hover:underline">
+        Podmienky používania
+      </a>
+    </nav>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,21 +1,45 @@
 import React from 'react';
 
 export default function Navigation() {
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
   return (
     <nav className="mt-12 flex flex-wrap justify-center gap-4 text-sm">
-      <a href="#/about" className="text-blue-600 hover:underline">
+      <a
+        href="#/about"
+        onClick={scrollToTop}
+        className="text-blue-600 hover:underline"
+      >
         Domov
       </a>
-      <a href="#/attendance" className="text-blue-600 hover:underline">
+      <a
+        href="#/attendance"
+        onClick={scrollToTop}
+        className="text-blue-600 hover:underline"
+      >
         Dochádzka
       </a>
-      <a href="#/tutorials" className="text-blue-600 hover:underline">
+      <a
+        href="#/tutorials"
+        onClick={scrollToTop}
+        className="text-blue-600 hover:underline"
+      >
         Návody
       </a>
-      <a href="#/faq" className="text-blue-600 hover:underline">
+      <a
+        href="#/faq"
+        onClick={scrollToTop}
+        className="text-blue-600 hover:underline"
+      >
         Časté otázky
       </a>
-      <a href="#/terms" className="text-blue-600 hover:underline">
+      <a
+        href="#/terms"
+        onClick={scrollToTop}
+        className="text-blue-600 hover:underline"
+      >
         Podmienky používania
       </a>
     </nav>


### PR DESCRIPTION
## Summary
- add Navigation component with links to major pages
- show navigation links at the bottom of Tutorials and FAQ pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689da0ab15b88332b77edea048ccb325