### PR TITLE
Add privacy policy page and update navigation

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,4 +6,5 @@
   <url><loc>https://vykazuje.me/faq</loc></url>
   <url><loc>https://vykazuje.me/tutorials</loc></url>
   <url><loc>https://vykazuje.me/terms</loc></url>
+  <url><loc>https://vykazuje.me/privacy</loc></url>
 </urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import About from './About';
 import FAQ from './FAQ';
 import Tutorials from './Tutorials';
 import Terms from './Terms';
+import Privacy from './Privacy';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 import Footer from './components/Footer';
@@ -30,6 +31,8 @@ function App() {
         return <Tutorials />;
       case '#/terms':
         return <Terms />;
+      case '#/privacy':
+        return <Privacy />;
       case '#/attendance':
       default:
         return <Attendance />;

--- a/src/Privacy.tsx
+++ b/src/Privacy.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function Privacy(): JSX.Element {
+  return (
+    <div className="flex items-center justify-center min-h-full py-10">
+      <div className="max-w-2xl w-full bg-white/90 border border-gray-200 rounded-lg shadow p-6 space-y-4">
+        <h1 className="text-3xl md:text-4xl font-bold text-center">Ochrana súkromia</h1>
+        <p className="text-gray-700">
+          Vaše súkromie je pre nás dôležité. Táto politika opisuje, aké údaje zbierame a ako ich používame.
+        </p>
+        <p className="text-gray-700">
+          Webová stránka používa súbory cookies na zabezpečenie správneho fungovania a na anonymné meranie návštevnosti.
+          Cookies si môžete vo svojom prehliadači kedykoľvek vypnúť alebo vymazať.
+        </p>
+        <p className="text-gray-700">
+          Zhromaždené údaje nepredávame ani neposkytujeme tretím stranám a slúžia výhradne na zlepšovanie našich služieb.
+        </p>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 export default function Footer() {
   return (
     <footer className='fixed left-0 bottom-0 w-full bg-black text-white text-xs p-2'>
-      Pinit, s.r.o (2025). All rights reserved
+      Pinit, s.r.o (2025). All rights reserved.{' '}
+      <a href='#/privacy' className='text-gray-300 hover:underline'>Ochrana súkromia</a>
     </footer>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle, BookOpen, ClipboardList, Home, FileText } from 'lucide-react';
+import { HelpCircle, BookOpen, ClipboardList, Home, FileText, Shield } from 'lucide-react';
 import classes from './Sidebar.module.scss';
 
 interface SidebarProps {
@@ -66,6 +66,17 @@ export default function Sidebar({ isOpen, currentPage }: SidebarProps) {
           >
             <FileText size={16} />
             Podmienky používania
+          </a>
+          <a
+            href='#/privacy'
+            className={`flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${
+              currentPage === '#/privacy'
+                ? 'bg-gray-200 text-gray-900 font-medium'
+                : ''
+            }`}
+          >
+            <Shield size={16} />
+            Ochrana súkromia
           </a>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- add privacy policy page describing data handling and cookie usage
- link privacy policy from sidebar, footer and router
- update sitemap with privacy URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ed2634c1c8332b551333bc736a98d