### PR TITLE
docs: document CSV and Excel export options

### DIFF
--- a/src/FAQ.tsx
+++ b/src/FAQ.tsx
@@ -94,12 +94,13 @@ export default function FAQ(): JSX.Element {
 
       <section className='space-y-2'>
         <h2 className='text-xl font-semibold'>
-          Je možné exportovať dochádzku do Excelu?
+          Je možné exportovať dochádzku do CSV alebo Excelu?
         </h2>
         <p>
-          Momentálne nástroj podporuje len tlač do PDF alebo priamo na papier.
-          Export do Excelu zatiaľ nie je k dispozícii, ale je v pláne ako budúca
-          funkcia.
+          Áno. Vedľa tlačidla <kbd>Tlačiť</kbd> nájdete aj možnosti
+          <kbd>Download CSV</kbd> a <kbd>Download Excel</kbd>. Tieto tlačidlá
+          vám umožnia uložiť vyplnenú dochádzku do súboru na vašom zariadení,
+          ktorý si môžete neskôr otvoriť v tabuľkovom procesore.
         </p>
       </section>
 

--- a/src/Tutorials.tsx
+++ b/src/Tutorials.tsx
@@ -122,6 +122,15 @@ export default function Tutorials(): JSX.Element {
             pre náhľad a uloženie alebo tlač.
           </p>
         </section>
+
+        <section>
+          <h2 className='text-2xl font-semibold'>Stiahnutie do CSV alebo Excelu</h2>
+          <p>
+            Vedľa tlačidla <kbd>Tlačiť</kbd> nájdete aj možnosti
+            <kbd>Download CSV</kbd> a <kbd>Download Excel</kbd>, ktoré umožnia
+            exportovať vyplnenú dochádzku do súboru pre ďalšie spracovanie.
+          </p>
+        </section>
       </article>
 
       <article className='max-w-3xl mx-auto space-y-10 text-gray-800 leading-relaxed mt-8'>
@@ -209,11 +218,12 @@ export default function Tutorials(): JSX.Element {
             súhrne.
           </p>
 
-          <h3 className='text-xl font-semibold'>Krok 7: Tlač alebo uloženie</h3>
+          <h3 className='text-xl font-semibold'>Krok 7: Tlač alebo stiahnutie</h3>
           <p>
-            Po dokončení kliknite na tlačidlo <kbd>Tlačiť</kbd>. Prehliadač
-            otvorí náhľad tlače, kde môžete dokument priamo vytlačiť alebo
-            uložiť ako PDF.
+            Po dokončení kliknite na tlačidlo <kbd>Tlačiť</kbd> pre náhľad a
+            prípadnú tlač. Ak chcete pracovať s údajmi ďalej, použite tlačidlá
+            <kbd>Download CSV</kbd> alebo <kbd>Download Excel</kbd>, ktoré vám
+            stiahnu dochádzku do súboru vo zvolenom formáte.
           </p>
 
           <p>


### PR DESCRIPTION
## Summary
- mention CSV and Excel download buttons in FAQ
- explain how to export to CSV and Excel in tutorials page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a084698d5483329a5dc4b1cb4c631e