### PR TITLE
Serve About page at root without redirect

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <url><loc>https://vykazuje.me/</loc></url>
   <url><loc>https://vykazuje.me/attendance</loc></url>
-  <url><loc>https://vykazuje.me/about</loc></url>
   <url><loc>https://vykazuje.me/faq</loc></url>
   <url><loc>https://vykazuje.me/tutorials</loc></url>
   <url><loc>https://vykazuje.me/terms</loc></url>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -21,11 +21,6 @@ const pages = {
     title: 'Vykazujeme – O projekte',
     description: 'Informácie o projekte Vykazujeme.',
   },
-  about: {
-    url: '/src/About.tsx',
-    title: 'Vykazujeme – O projekte',
-    description: 'Informácie o projekte Vykazujeme.',
-  },
   faq: {
     url: '/src/FAQ.tsx',
     title: 'Vykazujeme – FAQ',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,13 +21,13 @@ function App() {
         <Sidebar isOpen={open} />
         <div className='p-6 mt-6 flex-1 pt-16 md:pt-0'>
           <Routes>
-            <Route path='/about' element={<About />} />
+            <Route path='/' element={<About />} />
+            <Route path='/about' element={<Navigate to='/' replace />} />
             <Route path='/faq' element={<FAQ />} />
             <Route path='/tutorials' element={<Tutorials />} />
             <Route path='/terms' element={<Terms />} />
             <Route path='/privacy' element={<Privacy />} />
             <Route path='/attendance' element={<Attendance />} />
-            <Route path='/' element={<Navigate to='/about' replace />} />
           </Routes>
         </div>
       </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,7 +8,7 @@ export default function Navigation() {
   return (
     <nav className="mt-12 flex flex-wrap justify-center gap-4 text-sm">
       <a
-        href="/about"
+        href="/"
         onClick={scrollToTop}
         className="text-blue-600 hover:underline"
       >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,7 +12,7 @@ export default function Sidebar({ isOpen }: SidebarProps) {
       <div className={classes.sidebar__content}>
         <nav className='flex flex-col space-y-2 p-2'>
           <NavLink
-            to='/about'
+            to='/'
             className={({ isActive }) =>
               `flex items-center gap-2 px-2 py-1 rounded no-underline text-gray-700 hover:text-gray-900 hover:bg-gray-100 ${
                 isActive ? 'bg-gray-200 text-gray-900 font-medium' : ''


### PR DESCRIPTION
## Summary
- Render About component directly for `/` and redirect `/about` back to root
- Update navigation links and sitemap to use root as home
- Drop duplicate About route from prerender config

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac57b136848332b47becc41a85a7f8