### PR TITLE
feat: brand meta descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Jednoduchý nástroj na generovanie a evidenciu pracovnej dochádzky."
+      content="Vykazujeme – jednoduchý nástroj na generovanie a evidenciu pracovnej dochádzky."
     />
     <meta
       name="keywords"
@@ -16,7 +16,7 @@
     <meta property="og:title" content="Vykazujeme" />
     <meta
       property="og:description"
-      content="Jednoduchý nástroj na generovanie a evidenciu pracovnej dochádzky."
+      content="Vykazujeme – jednoduchý nástroj na generovanie a evidenciu pracovnej dochádzky."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://vykazuje.me/" />

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -39,7 +39,7 @@ const pages = {
   attendance: {
     url: '/src/Attendance.tsx',
     title: 'Vykazujeme – Dochádza',
-    description: 'Jednoduchý nástroj na generovanie a evidenciu pracovnej dochádzky.',
+    description: 'Vykazujeme – jednoduchý nástroj na generovanie a evidenciu pracovnej dochádzky.',
   },
 };
 


### PR DESCRIPTION
## Summary
- start default meta descriptions with "Vykazujeme –" branding
- include the brand in attendance page description for prerendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad8fa59ff08332b80125f7b0de0a40